### PR TITLE
Fix pbr version when deploying wsgi

### DIFF
--- a/templates/keystone-wsgi.py.j2
+++ b/templates/keystone-wsgi.py.j2
@@ -23,7 +23,7 @@ import pbr.version
 _version_ = pbr.version.VersionInfo('keystone').version_string()
 
 #TODO(cloudnull) This should be removed in the N time frame
-if '2015' in _version_:
+if '8.' in _version_:
     from keystone.server import wsgi as wsgi_server
     name = os.path.basename(__file__)
     application = wsgi_server.initialize_application(name)


### PR DESCRIPTION
We recently added a check when deploying the keystone.wsgi script that would
allow it to be smart enough to handle the keystone stable/liberty codebase and
master. This change was using 2015 as the keystone version but for
stable/liberty this has changed to 8.

This patch makes it so that the wsgi script matches what PBR gives back
for stable/liberty deployments.
