### PR TITLE
Add condition to the galera_client role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,7 +31,9 @@ galaxy_info:
     - openstack
 dependencies:
   - apt_package_pinning
-  - galera_client
+  - role: galera_client
+    when:
+      - keystone_database_enabled | bool
   - role: pip_lock_down
     when:
       - not keystone_developer_mode | bool


### PR DESCRIPTION
The conditional added to the galera client role checks to see if
`keystone_database_enabled` is true. If so the dep is rendered
else it'l lbe skipped.

Signed-off-by: Kevin Carter kevin.carter@rackspace.com
